### PR TITLE
feat(kafka): add producer for orders.v1 with seeds, tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -22,8 +22,18 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
 
+      - name: Cache Poetry & Pip
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --no-interaction --no-ansi
 
       - name: Run Ruff (Lint)
         run: poetry run ruff check .
@@ -31,5 +41,5 @@ jobs:
       - name: Run Black (Format Check)
         run: poetry run black --check .
 
-      - name: Run Pytest (allow empty)
-        run: poetry run pytest || true
+      - name: Run Pytest
+        run: poetry run pytest -v --maxfail=1

--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ docker exec -it retailops-lakehouse-kafka-1 \
 docker exec -it retailops-lakehouse-kafka-1 \
   kafka-topics --bootstrap-server kafka:9092 --describe --topic orders.v1
 ```
+
+## Tests
+
+Unit- und Build-Tests für den Kafka Producer sind enthalten.  
+Lokal ausführen mit:
+
+```bash
+poetry run pytest
+```
+
+Die Tests laufen außerdem automatisch in GitHub Actions (CI).

--- a/README.md
+++ b/README.md
@@ -24,3 +24,18 @@ Ziel: Von Event-Streaming über Datenmodellierung bis zur Bereitstellung von KPI
 - **Orchestrierung/Modellierung**: Airflow, dbt
 - **Serving**: FastAPI (folgt)
 - **Infra**: Docker Compose
+
+## Kafka Setup
+
+Nach dem Start der Docker-Umgebung (`docker compose up -d`) muss das Topic **orders.v1** einmalig angelegt werden:
+
+```bash
+# Topic erstellen (3 Partitionen, keine Replikation)
+docker exec -it retailops-lakehouse-kafka-1 \
+  kafka-topics --bootstrap-server kafka:9092 --create \
+  --topic orders.v1 --partitions 3 --replication-factor 1
+
+# Kontrolle
+docker exec -it retailops-lakehouse-kafka-1 \
+  kafka-topics --bootstrap-server kafka:9092 --describe --topic orders.v1
+```

--- a/data/seeds/customers.csv
+++ b/data/seeds/customers.csv
@@ -1,0 +1,16 @@
+customer_id,country
+c_1,DE
+c_2,DE
+c_3,DE
+c_4,AT
+c_5,AT
+c_6,CH
+c_7,CH
+c_8,UK
+c_9,UK
+c_10,FR
+c_11,FR
+c_12,NL
+c_13,NL
+c_14,ES
+c_15,IT

--- a/data/seeds/products.csv
+++ b/data/seeds/products.csv
@@ -1,0 +1,11 @@
+product_id,category,price_min,price_max
+p_1,accessories,5,25
+p_2,accessories,10,40
+p_3,home,15,60
+p_4,home,30,120
+p_5,electronics,50,200
+p_6,electronics,150,800
+p_7,clothing,20,90
+p_8,clothing,10,50
+p_9,beauty,5,70
+p_10,books,8,30

--- a/data_gen/produce_orders.py
+++ b/data_gen/produce_orders.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import random
+import signal
+import sys
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+
+ROOT = Path(__file__).resolve().parents[1]
+SEEDS_DIR = ROOT / "data" / "seeds"
+PRODUCTS_CSV = SEEDS_DIR / "products.csv"
+CUSTOMERS_CSV = SEEDS_DIR / "customers.csv"
+
+
+def load_products():
+    products = []
+    with PRODUCTS_CSV.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            products.append(
+                {
+                    "product_id": row["product_id"],
+                    "category": row["category"],
+                    "price_min": float(row["price_min"]),
+                    "price_max": float(row["price_max"]),
+                }
+            )
+    if not products:
+        raise RuntimeError("products.csv leer")
+    return products
+
+
+def load_customers():
+    customers = []
+    with CUSTOMERS_CSV.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            customers.append(
+                {
+                    "customer_id": row["customer_id"],
+                    "country": row["country"],
+                }
+            )
+    if not customers:
+        raise RuntimeError("customers.csv leer")
+    return customers
+
+
+def make_item(prod: dict) -> dict:
+    qty = random.randint(1, 3)
+    price = round(random.uniform(prod["price_min"], prod["price_max"]), 2)
+    return {
+        "product_id": prod["product_id"],
+        "qty": qty,
+        "unit_price": price,
+        "category": prod["category"],
+    }
+
+
+def make_order(customers, products) -> dict:
+    cust = random.choice(customers)
+    items = [make_item(random.choice(products)) for _ in range(random.randint(1, 3))]
+    total = round(sum(i["qty"] * i["unit_price"] for i in items), 2)
+    return {
+        "order_id": str(uuid.uuid4()),
+        "customer_id": cust["customer_id"],
+        "ts": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "items": items,
+        "total_amount": total,
+        "country": cust["country"],
+    }
+
+
+def build_producer(bootstrap: str) -> KafkaProducer:
+    return KafkaProducer(
+        bootstrap_servers=bootstrap,
+        acks="all",
+        linger_ms=50,
+        retries=10,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        key_serializer=lambda v: v.encode("utf-8") if v is not None else None,
+    )
+
+
+stop = False
+
+
+def _sigint_handler(_sig, _frm):
+    global stop
+    stop = True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Orders producer")
+    parser.add_argument(
+        "--bootstrap", default="localhost:9093", help="Kafka bootstrap servers"
+    )
+    parser.add_argument("--topic", default="orders.v1", help="Kafka topic")
+    parser.add_argument("--eps", type=float, default=10.0, help="Events pro Sekunde")
+    parser.add_argument("--max", type=int, default=0, help="Max Events (0 = unendlich)")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed")
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    if not PRODUCTS_CSV.exists() or not CUSTOMERS_CSV.exists():
+        sys.exit(f"Seeds nicht gefunden unter {SEEDS_DIR}")
+
+    products = load_products()
+    customers = load_customers()
+    producer = build_producer(args.bootstrap)
+
+    signal.signal(signal.SIGINT, _sigint_handler)
+    signal.signal(signal.SIGTERM, _sigint_handler)
+
+    interval = 1.0 / max(args.eps, 0.001)
+    sent = 0
+    try:
+        while not stop and (args.max == 0 or sent < args.max):
+            evt = make_order(customers, products)
+            key = evt["customer_id"]
+            future = producer.send(args.topic, key=key, value=evt)
+            try:
+                future.get(timeout=10)
+            except KafkaError as e:
+                print(f"Send-Fehler: {e}", file=sys.stderr)
+            sent += 1
+            time.sleep(interval)
+    finally:
+        producer.flush()
+        producer.close()
+        print(f"Beendet. Gesendet: {sent}")
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,6 +82,25 @@ files = [
 ]
 
 [[package]]
+name = "kafka-python"
+version = "2.2.15"
+description = "Pure Python client for Apache Kafka"
+optional = false
+python-versions = "*"
+files = [
+    {file = "kafka_python-2.2.15-py2.py3-none-any.whl", hash = "sha256:84c0993cd4f7f2f01e92d8104ea9bdf631aff72fc5e6ea62eb3bdf1d56528fc3"},
+    {file = "kafka_python-2.2.15.tar.gz", hash = "sha256:e0f480a45f3814cb0eb705b8b4f61069e1be61dae0d8c69d0f1f2da33eea1bd5"},
+]
+
+[package.extras]
+benchmarks = ["pyperf"]
+crc32c = ["crc32c"]
+lz4 = ["lz4"]
+snappy = ["python-snappy"]
+testing = ["mock", "pytest", "pytest-mock", "pytest-timeout"]
+zstd = ["zstandard"]
+
+[[package]]
 name = "mypy"
 version = "1.18.2"
 description = "Optional static typing for Python"
@@ -295,4 +314,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "07dc85fa72aa54d5b4ce8eb53d861a5ecf80a4f8960331d51000762a1d20559f"
+content-hash = "946a5bd5c1f3dee726807d5fe176a5618b7c7c5b826a77a4e0590f8a01b6c642"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ pytest = "^8.4.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-v"
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
+kafka-python = "^2.2.15"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_producer_build.py
+++ b/tests/test_producer_build.py
@@ -1,0 +1,88 @@
+import json
+import random
+from datetime import datetime
+from unittest.mock import patch
+
+from data_gen import produce_orders as mod
+
+
+def test_build_producer_params():
+    calls = {}
+
+    class DummyKP:
+        def __init__(self, **kwargs):
+            calls["kwargs"] = kwargs
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    with patch.object(mod, "KafkaProducer", DummyKP):
+        _ = mod.build_producer("localhost:9093")
+        kw = calls["kwargs"]
+
+        assert kw["bootstrap_servers"] == "localhost:9093"
+        assert kw["acks"] == "all"
+        assert kw["linger_ms"] == 50
+        assert kw["retries"] == 10
+
+        v = kw["value_serializer"]({"x": 1})
+        assert isinstance(v, (bytes, bytearray))
+        assert json.loads(v.decode("utf-8")) == {"x": 1}
+
+        assert kw["key_serializer"]("k") == b"k"
+        assert kw["key_serializer"](None) is None
+
+
+def test_make_item_and_order_shapes():
+    products = [
+        {"product_id": "P1", "category": "fruit", "price_min": 1.0, "price_max": 2.0}
+    ]
+    customers = [{"customer_id": "C1", "country": "DE"}]
+
+    item = mod.make_item(products[0])
+    assert {"product_id", "qty", "unit_price", "category"} <= item.keys()
+    assert 1 <= item["qty"] <= 3
+    assert products[0]["price_min"] <= item["unit_price"] <= products[0]["price_max"]
+
+    order = mod.make_order(customers, products)
+    assert {
+        "order_id",
+        "customer_id",
+        "ts",
+        "items",
+        "total_amount",
+        "country",
+    } <= order.keys()
+
+    # ts parsbar als ISO-8601
+    datetime.fromisoformat(order["ts"].replace("Z", "+00:00"))
+
+    total = round(sum(i["qty"] * i["unit_price"] for i in order["items"]), 2)
+    assert abs(order["total_amount"] - total) < 1e-6
+    assert order["customer_id"] == "C1"
+    assert order["country"] == "DE"
+
+
+def test_seed_reproducibility():
+    products = [
+        {"product_id": "P1", "category": "fruit", "price_min": 1.0, "price_max": 2.0},
+        {"product_id": "P2", "category": "veg", "price_min": 3.0, "price_max": 4.0},
+    ]
+    customers = [
+        {"customer_id": "C1", "country": "DE"},
+        {"customer_id": "C2", "country": "AT"},
+    ]
+
+    random.seed(42)
+    a = mod.make_order(customers, products)
+    random.seed(42)
+    b = mod.make_order(customers, products)
+
+    # order_id und ts variieren immer → ausblenden
+    def strip(d):
+        return {k: v for k, v in d.items() if k not in {"order_id", "ts"}}
+
+    assert strip(a) == strip(b)

--- a/tests/test_producer_unit.py
+++ b/tests/test_producer_unit.py
@@ -1,0 +1,47 @@
+import random
+
+from data_gen.produce_orders import load_customers, load_products, make_item, make_order
+
+
+def test_load_seeds():
+    prods = load_products()
+    custs = load_customers()
+    assert len(prods) >= 1
+    assert len(custs) >= 1
+    for p in prods:
+        assert {"product_id", "category", "price_min", "price_max"} <= p.keys()
+        assert p["price_min"] <= p["price_max"]
+
+
+def test_make_item_respects_price_bounds():
+    random.seed(123)
+    p = {"product_id": "p_1", "category": "x", "price_min": 5.0, "price_max": 10.0}
+    it = make_item(p)
+    assert 5.0 <= it["unit_price"] <= 10.0
+    assert it["qty"] in (1, 2, 3)
+    assert it["product_id"] == "p_1"
+
+
+def test_make_order_schema_and_total():
+    random.seed(123)
+    prods = [
+        {"product_id": "p_1", "category": "c", "price_min": 5.0, "price_max": 5.0},
+        {"product_id": "p_2", "category": "c", "price_min": 2.0, "price_max": 2.0},
+    ]
+    custs = [{"customer_id": "c_1", "country": "DE"}]
+    o = make_order(custs, prods)
+
+    assert {
+        "order_id",
+        "customer_id",
+        "ts",
+        "items",
+        "total_amount",
+        "country",
+    } <= o.keys()
+    assert o["customer_id"] == "c_1"
+    assert o["country"] == "DE"
+    assert len(o["items"]) >= 1
+
+    total = sum(i["qty"] * i["unit_price"] for i in o["items"])
+    assert abs(o["total_amount"] - total) < 1e-6


### PR DESCRIPTION
	•	Producer-Skript (data_gen/produce_orders.py)
	•	Seeds (data/seeds/*)
	•	Tests (tests/test_producer_*)
	•	CI (ci.yml)
	•	Manuelles Setup: Kafka-Topic orders.v1 (README → Kafka Setup)