### PR TITLE
Add dev scripts and Makefile integration for local workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Kafka
+KAFKA_BOOTSTRAP_HOST=localhost:9093
+KAFKA_BOOTSTRAP_CONTAINER=kafka:9092
+TOPIC=orders.v1
+EPS=10
+MAX_EVENTS=0
+SEED=
+PARTITIONS=3
+REPLICATION=1
+STARTING_OFFSETS=earliest      # oder latest
+
+# Spark
+BRONZE_OUTPUT_PATH=/lake/bronze/orders
+BRONZE_CHECKPOINT_PATH=/lake/checkpoints/orders_bronze
+BRONZE_BAD_PATH=/lake/bronze/orders_corrupt
+
+# Docker Container Names
+KAFKA_CONTAINER=retailops-lakehouse-kafka-1
+SPARK_CONTAINER=retailops-lakehouse-spark-1
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Makefile
+
+.PHONY: up producer topic bronze logs head down
+
+up:
+	@./scripts/start_stack.sh
+
+producer:
+	@{ [ -f .env ] || echo "Hinweis: .env nicht gefunden – nutze Defaults"; } >/dev/null; \
+	set -a; [ -f .env ] && . .env; set +a; \
+	poetry run python data_gen/produce_orders.py \
+		--bootstrap "$${KAFKA_BOOTSTRAP:-localhost:9093}" \
+		--topic "$${TOPIC:-orders.v1}" \
+		--eps "$${EPS:-10}" \
+		--max "$${MAX_EVENTS:-0}" \
+		$${SEED:+--seed $$SEED}
+
+topic:
+	@set -a; [ -f .env ] && . .env; set +a; \
+	docker exec -it "$${KAFKA_CONTAINER:-retailops-lakehouse-kafka-1}" \
+	  kafka-topics --bootstrap-server kafka:9092 --describe --topic "$${TOPIC:-orders.v1}"
+
+bronze:
+	@./scripts/run_bronze.sh
+
+logs:
+	@set -a; [ -f .env ] && . .env; set +a; \
+	docker exec -it "$${SPARK_CONTAINER:-retailops-lakehouse-spark-1}" \
+	  sh -lc '[ -f /tmp/bronze.log ] && tail -n 200 -f /tmp/bronze.log || echo "kein /tmp/bronze.log"'
+
+head:
+	@./scripts/head_bronze.sh
+
+down:
+	@DO_DOWN=true ./scripts/stop_stack.sh

--- a/README.md
+++ b/README.md
@@ -25,19 +25,28 @@ Ziel: Von Event-Streaming über Datenmodellierung bis zur Bereitstellung von KPI
 - **Serving**: FastAPI (folgt)
 - **Infra**: Docker Compose
 
-## Kafka Setup
+## Lokale Befehle
 
-Nach dem Start der Docker-Umgebung (`docker compose up -d`) muss das Topic **orders.v1** einmalig angelegt werden:
+Die wichtigsten Schritte laufen jetzt über das `Makefile`.  
+Vorher `.env.example` kopieren und ggf. anpassen (enthält Container-Namen und Pfade):
 
 ```bash
-# Topic erstellen (3 Partitionen, keine Replikation)
-docker exec -it retailops-lakehouse-kafka-1 \
-  kafka-topics --bootstrap-server kafka:9092 --create \
-  --topic orders.v1 --partitions 3 --replication-factor 1
+cp .env.example .env
 
-# Kontrolle
-docker exec -it retailops-lakehouse-kafka-1 \
-  kafka-topics --bootstrap-server kafka:9092 --describe --topic orders.v1
+# Stack starten (Zookeeper, Kafka, Spark, MinIO, Postgres, Airflow)
+make up
+# Producer starten (Events ins Kafka-Topic schicken)
+make producer
+# Bronze-Streaming-Job starten
+make bronze
+# Logs des Bronze-Jobs verfolgen
+make logs
+# Kafka-Topic-Infos anzeigen
+make topic
+# Einen Blick in die ersten Parquet-Dateien werfen
+make head
+# Stack stoppen
+make down
 ```
 
 ## Bronze Layer (Orders)
@@ -53,33 +62,6 @@ Erster Streaming-Job für den **Bronze Layer** mit Spark:
   - Grundlage für weitere Transformationen in Silver/Gold Layer
   - Sicherung auch bei Streaming-Ausfällen
 
-## Bronze Job manuell starten
-
-Der Bronze-Job kann manuell gestartet werden, **sobald der Producer Nachrichten ins Kafka-Topic `orders.v1` schreibt**:
-
-```bash
-# 1) Ivy-Cache anlegen (nur einmal nötig)
-docker exec retailops-lakehouse-spark-1 mkdir -p /tmp/.ivy2
-
-# 2) Job starten (mit ENV Variablen)
-docker exec -it \
-  -u 0 \
-  -e USER=root \
-  -e HOME=/root \
-  -e HADOOP_USER_NAME=root \
-  -e BRONZE_OUTPUT_PATH=/lake/bronze/orders \
-  -e BRONZE_CHECKPOINT_PATH=/lake/checkpoints/orders_bronze \
-  -e BRONZE_BAD_PATH=/lake/bronze/orders_corrupt \
-  retailops-lakehouse-spark-1 \
-  /opt/bitnami/spark/bin/spark-submit \
-    --conf spark.jars.ivy=/tmp/.ivy2 \
-    --conf spark.hadoop.hadoop.security.authentication=simple \
-    --conf "spark.driver.extraJavaOptions=-Duser.name=root" \
-    --conf "spark.executor.extraJavaOptions=-Duser.name=root" \
-    --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.0 \
-    /opt/spark_jobs/bronze_orders.py
-```
-
 ## Tests
 
 Unit- und Build-Tests für den Kafka Producer sowie für den Bronze-Job sind enthalten.
@@ -91,5 +73,3 @@ poetry run pytest
 
 Die Tests prüfen Producer-Logik, Schema-Validierung und einen Smoke-Test für den Bronze-Stream.
 Sie laufen außerdem automatisch in GitHub Actions (CI).
-
-Die Tests laufen außerdem automatisch in GitHub Actions (CI).

--- a/data_gen/produce_orders.py
+++ b/data_gen/produce_orders.py
@@ -2,6 +2,7 @@
 import argparse
 import csv
 import json
+import os
 import random
 import signal
 import sys
@@ -98,12 +99,32 @@ def _sigint_handler(_sig, _frm):
 def main():
     parser = argparse.ArgumentParser(description="Orders producer")
     parser.add_argument(
-        "--bootstrap", default="localhost:9093", help="Kafka bootstrap servers"
+        "--bootstrap",
+        default=os.getenv("KAFKA_BOOTSTRAP", "localhost:9093"),
+        help="Kafka bootstrap servers",
     )
-    parser.add_argument("--topic", default="orders.v1", help="Kafka topic")
-    parser.add_argument("--eps", type=float, default=10.0, help="Events pro Sekunde")
-    parser.add_argument("--max", type=int, default=0, help="Max Events (0 = unendlich)")
-    parser.add_argument("--seed", type=int, default=None, help="Random seed")
+    parser.add_argument(
+        "--topic", default=os.getenv("TOPIC", "orders.v1"), help="Kafka topic"
+    )
+    parser.add_argument(
+        "--eps",
+        type=float,
+        default=float(os.getenv("EPS", "10")),
+        help="Events pro Sekunde",
+    )
+    parser.add_argument(
+        "--max",
+        type=int,
+        default=int(os.getenv("MAX_EVENTS", "0")),
+        help="Max Events (0 = unendlich)",
+    )
+    seed_env = os.getenv("SEED")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=(int(seed_env) if seed_env not in (None, "") else None),
+        help="Random seed",
+    )
     args = parser.parse_args()
 
     if args.seed is not None:

--- a/scripts/head_bronze.sh
+++ b/scripts/head_bronze.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- .env laden + Defaults ---
+ENV_FILE="${ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+#!/usr/bin/env bash
+set -euo pipefail
+source .env
+
+SQL="
+CREATE OR REPLACE TEMP VIEW bronze_orders
+USING parquet
+OPTIONS (path '${BRONZE_OUTPUT_PATH}');
+
+SELECT
+  p_date,
+  order_id,
+  customer_id,
+  total_amount,
+  country,
+  ingested_at
+FROM bronze_orders
+ORDER BY ingested_at DESC
+LIMIT 5
+"
+
+docker exec -it \
+  -u 0 \
+  -e USER=root \
+  -e HOME=/root \
+  -e HADOOP_USER_NAME=root \
+  "${SPARK_CONTAINER}" \
+  /opt/bitnami/spark/bin/spark-sql \
+    --conf spark.hadoop.hadoop.security.authentication=simple \
+    -e "${SQL}"

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a; . "$ENV_FILE"; set +a
+fi
+
+echo "==> Zeige Bronze-Logs aus $SPARK_CONTAINER:/tmp/bronze.log"
+docker exec -it "$SPARK_CONTAINER" sh -lc '
+  if [ -f /tmp/bronze.log ]; then
+    tail -n 200 -f /tmp/bronze.log
+  else
+    echo "⚠️  Keine /tmp/bronze.log gefunden"
+    exit 1
+  fi
+'

--- a/scripts/run_bronze.sh
+++ b/scripts/run_bronze.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .env laden
+ENV_FILE="${ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a; . "$ENV_FILE"; set +a
+fi
+
+echo "==> Starte Bronze-Job detached…"
+docker exec -u 0 -d "$SPARK_CONTAINER" sh -lc "\
+  export USER=root HOME=/root HADOOP_USER_NAME=root \
+         JAVA_TOOL_OPTIONS='-Duser.name=root' \
+         SPARK_SUBMIT_OPTS='-Duser.name=root' \
+         PYSPARK_PYTHON=/opt/bitnami/python/bin/python \
+         PYSPARK_DRIVER_PYTHON=/opt/bitnami/python/bin/python \
+         BRONZE_OUTPUT_PATH='${BRONZE_OUTPUT_PATH}' \
+         BRONZE_CHECKPOINT_PATH='${BRONZE_CHECKPOINT_PATH}' \
+         BRONZE_BAD_PATH='${BRONZE_BAD_PATH}' \
+         KAFKA_BOOTSTRAP='${KAFKA_BOOTSTRAP:-kafka:9092}' \
+         TOPIC='${TOPIC:-orders.v1}' \
+         STARTING_OFFSETS='${STARTING_OFFSETS:-earliest}'; \
+  nohup /opt/bitnami/spark/bin/spark-submit \
+    --conf spark.jars.ivy=/tmp/.ivy2 \
+    --conf spark.hadoop.hadoop.security.authentication=simple \
+    --conf 'spark.driver.extraJavaOptions=-Duser.name=root' \
+    --conf 'spark.executor.extraJavaOptions=-Duser.name=root' \
+    --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.0 \
+    /opt/spark_jobs/bronze_orders.py \
+    > /tmp/bronze.log 2>&1 & echo \$! > /tmp/bronze.pid
+"
+echo "✅ Bronze läuft. Logs: make logs   |  Head: make head"

--- a/scripts/start_stack.sh
+++ b/scripts/start_stack.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .env laden (falls vorhanden) und Variablen exportieren
+ENV_FILE="${ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+echo "==> docker compose up…"
+docker compose up -d
+
+echo "==> warte auf Kafka…"
+for i in {1..30}; do
+  if docker exec "$KAFKA_CONTAINER" kafka-topics --bootstrap-server kafka:9092 --list >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "==> Topic prüfen/erstellen: $TOPIC"
+if ! docker exec "$KAFKA_CONTAINER" kafka-topics --bootstrap-server kafka:9092 --list | grep -q "^${TOPIC}\$"; then
+  docker exec -it "$KAFKA_CONTAINER" kafka-topics \
+    --bootstrap-server kafka:9092 \
+    --create --topic "$TOPIC" \
+    --partitions "$PARTITIONS" \
+    --replication-factor "$REPLICATION"
+else
+  echo "    Topic existiert."
+fi
+
+echo "==> Ivy-Cache im Spark-Container…"
+docker exec "$SPARK_CONTAINER" mkdir -p /tmp/.ivy2
+
+echo "✅ Stack bereit. Starte nun: make bronze  (oder ./scripts/run_bronze.sh)"

--- a/scripts/stop_stack.sh
+++ b/scripts/stop_stack.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- .env laden + Defaults ---
+ENV_FILE="${ENV_FILE:-.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+# --- Helper ---
+container_running() {
+  docker ps --format '{{.Names}}' | grep -qx "$1"
+}
+
+echo "==> Bronze-Job (falls laufend) beenden…"
+if container_running "$SPARK_CONTAINER"; then
+  # Versuche, einen evtl. laufenden bronze_orders-Job im Container zu beenden
+  docker exec "$SPARK_CONTAINER" sh -lc '
+    set -e
+    PIDS=$(ps -eo pid,cmd \
+      | grep -E "spark-submit.*bronze_orders\.py|python .*bronze_orders\.py" \
+      | grep -v grep \
+      | awk "{print \$1}")
+    if [ -n "$PIDS" ]; then
+      echo "Gefundene PIDs: $PIDS"
+      kill -TERM $PIDS || true
+      sleep 2
+      kill -KILL $PIDS || true
+    else
+      echo "Kein Bronze-Prozess gefunden – überspringe."
+    fi
+  ' || true
+else
+  echo "Spark-Container '$SPARK_CONTAINER' läuft nicht – überspringe Bronze-Stop."
+fi
+
+echo "==> Docker-Stack herunterfahren…"
+# Orphans entfernen, aber nicht hart fehlschlagen, wenn schon down
+docker compose down --remove-orphans || true
+
+echo "✅ Stop abgeschlossen."
+exit 0

--- a/spark_jobs/bronze_orders.py
+++ b/spark_jobs/bronze_orders.py
@@ -6,10 +6,11 @@ from pyspark.sql import functions as F
 from pyspark.sql import types as T
 
 APP_NAME = "bronze_orders"
-KAFKA_BOOTSTRAP = "kafka:9092"
-KAFKA_TOPIC = "orders.v1"
 
-# ENV-Override für Tests/CI
+KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP", "kafka:9092")
+KAFKA_TOPIC = os.getenv("TOPIC", "orders.v1")
+STARTING_OFFSETS = os.getenv("STARTING_OFFSETS", "earliest")
+
 OUTPUT_PATH = os.getenv("BRONZE_OUTPUT_PATH", "/lake/bronze/orders")
 CHECKPOINT_PATH = os.getenv("BRONZE_CHECKPOINT_PATH", "/lake/checkpoints/orders_bronze")
 BAD_RECORDS_PATH = os.getenv("BRONZE_BAD_PATH", "/lake/bronze/orders_corrupt")


### PR DESCRIPTION
- Added Makefile targets (up, down, producer, bronze, logs, topic, head)
- Introduced helper scripts in `scripts/` for reproducible commands
- Added `.env.example` for configurable container references
- Updated README with local workflow instructions (Makefile usage, env setup)